### PR TITLE
*rodslogErrors: ignore expected errors Yoda 1.6

### DIFF
--- a/zabbix-irodscommon/dailyRodslogErrors.sh
+++ b/zabbix-irodscommon/dailyRodslogErrors.sh
@@ -5,7 +5,13 @@
 # \copyright    Copyright (c) 2018, Utrecht University. All rights reserved.
 
 # gets latest log file.
-filepaths=$(sudo -u irods ls /var/lib/irods/log/rodsLog.* | tail -n 2)
+mapfile -t filepaths < <(sudo -u irods ls /var/lib/irods/log/rodsLog.* | tail -n 2)
 
 #counts lines containing ERROR in the current month day
-echo $(sudo -u irods grep "$(date +"%b %e")" $filepaths | grep -c "ERROR")
+sudo -u irods grep "$(date +"%b %e")" "${filepaths[@]}" | \
+  grep -v " ERROR: addMsParam: Two params have the same label ruleExecOut" | \
+  grep -v " ERROR: addMsParam: ... param is of type: ExecCmdOut_PI" | \
+  grep -v " ERROR: caught python exception: TypeError: No to_python (by-value)" | \
+  grep -v " ERROR: caught python exception:   File \"<string>\"" | \
+  grep -v " ERROR: Rule Engine Plugin returned \[0\]" | \
+  grep -c "ERROR:"

--- a/zabbix-irodscommon/hourlyRodslogErrors.sh
+++ b/zabbix-irodscommon/hourlyRodslogErrors.sh
@@ -5,7 +5,13 @@
 # \copyright    Copyright (c) 2018, Utrecht University. All rights reserved.
 
 # gets latest log file.
-filepaths=$(sudo -u irods ls /var/lib/irods/log/rodsLog.* | tail -n 2)
+mapfile -t filepaths < <(sudo -u irods ls /var/lib/irods/log/rodsLog.* | tail -n 2)
 
 #counts lines containing ERROR in the current month day hour
-echo $(sudo -u irods grep "$(date +"%b %e %H")" $filepaths | grep -c "ERROR")
+sudo -u irods grep "$(date +"%b %e %H")" "${filepaths[@]}" | \
+  grep -v " ERROR: addMsParam: Two params have the same label ruleExecOut" | \
+  grep -v " ERROR: addMsParam: ... param is of type: ExecCmdOut_PI" | \
+  grep -v " ERROR: caught python exception: TypeError: No to_python (by-value)" | \
+  grep -v " ERROR: caught python exception:   File \"<string>\"" | \
+  grep -v " ERROR: Rule Engine Plugin returned \[0\]" | \
+  grep -c "ERROR:"


### PR DESCRIPTION
Ignore expected harmless errors in Yoda 1.6 in the rodsLog error checks.
Also modify shell commands as per shellcheck recommendations.

If accepted, please also merge it into the release-branch for Yoda 1.6