### PR TITLE
YDA-6566: Update Zabbix log checks for Yoda 2.x

### DIFF
--- a/zabbix-irodscommon/dailyRodslogErrors.sh
+++ b/zabbix-irodscommon/dailyRodslogErrors.sh
@@ -5,13 +5,9 @@
 # \copyright    Copyright (c) 2018, Utrecht University. All rights reserved.
 
 # gets latest log file.
-mapfile -t filepaths < <(sudo -u irods ls /var/lib/irods/log/rodsLog.* | tail -n 2)
+mapfile -t filepaths < <(sudo -u irods ls /var/lib/irods-log/rodsLog-* | tail -n 2)
 
 # counts lines containing ERROR in the past 24 hours
 sudo -u irods /var/lib/irods/bin/read-irods-logs.py --last day  "${filepaths[@]}" | \
-  grep -v " ERROR: addMsParam: Two params have the same label ruleExecOut" | \
-  grep -v " ERROR: addMsParam: ... param is of type: ExecCmdOut_PI" | \
-  grep -v " ERROR: caught python exception: TypeError: No to_python (by-value)" | \
-  grep -v " ERROR: caught python exception:   File \"<string>\"" | \
-  grep -v " ERROR: Rule Engine Plugin returned \[0\]" | \
-  grep -c "ERROR:"
+  grep -v "readWorkerTask - readStartupPack failed." | \
+  grep -c ":error"

--- a/zabbix-irodscommon/hourlyRodslogErrors.sh
+++ b/zabbix-irodscommon/hourlyRodslogErrors.sh
@@ -5,13 +5,9 @@
 # \copyright    Copyright (c) 2018, Utrecht University. All rights reserved.
 
 # gets latest log file.
-mapfile -t filepaths < <(sudo -u irods ls /var/lib/irods/log/rodsLog.* | tail -n 2)
+mapfile -t filepaths < <(sudo -u irods ls /var/lib/irods-log/rodsLog-* | tail -n 2)
 
 # counts lines containing ERROR in the last hour
 sudo -u irods /var/lib/irods/bin/read-irods-logs.py --last hour  "${filepaths[@]}" | \
-  grep -v " ERROR: addMsParam: Two params have the same label ruleExecOut" | \
-  grep -v " ERROR: addMsParam: ... param is of type: ExecCmdOut_PI" | \
-  grep -v " ERROR: caught python exception: TypeError: No to_python (by-value)" | \
-  grep -v " ERROR: caught python exception:   File \"<string>\"" | \
-  grep -v " ERROR: Rule Engine Plugin returned \[0\]" | \
-  grep -c "ERROR:"
+  grep -v "readWorkerTask - readStartupPack failed." | \
+  grep -c ":error"

--- a/zabbix-irodscommon/read-irods-logs.py
+++ b/zabbix-irodscommon/read-irods-logs.py
@@ -5,14 +5,17 @@
 """
 
 import argparse
-from datetime import datetime, timedelta
-import os.path
+from datetime import datetime, timedelta, timezone
 import re
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("logfiles", nargs='+', help='The log files to search for')
-    parser.add_argument("-l", "--last", default ="hour", choices = ["hour", "day"],
+    parser.add_argument(
+        "logfiles",
+        nargs='+',
+        help='The log files to search for')
+    parser.add_argument("-l", "--last", default="hour", choices=["hour", "day"],
                         help="Show messages in last hour or day")
     parser.add_argument("-m", "--multi-line", action='store_true', default=False,
                         help="For multiline messages, print all lines instead of just the first one")
@@ -28,7 +31,7 @@ def get_recent_timestamps(args):
        than the number of minutes in a day.
     """
     result = set()
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
 
     if args.last == "hour":
         datetime_ref = now - timedelta(hours=1)
@@ -36,20 +39,19 @@ def get_recent_timestamps(args):
         datetime_ref = now - timedelta(days=1)
 
     while datetime_ref <= now:
-        result.add(datetime.strftime(datetime_ref, "%b %d %H:%M"))
+        result.add(datetime.strftime(datetime_ref, "%Y-%m-%dT%H:%M"))
         datetime_ref += timedelta(minutes=1)
-
     return result
 
 
 def process_logfile(logfile, recent_timestamps, args):
-    timestamp_re = re.compile(r"^(\w{3}\s+\d+\s+\d\d:\d\d):\d\d\s")
+    timestamp_re = re.compile(r"^(\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}):")
     with open(logfile, "r", errors="replace") as input:
         last_line_printed = False
         for line in input:
             line_match = timestamp_re.search(line)
             if line_match:
-                timestamp = line_match.group(1).replace("  ", " 0")
+                timestamp = line_match.group(1)
                 if timestamp in recent_timestamps:
                     print(line, end="")
                     last_line_printed = True
@@ -57,6 +59,7 @@ def process_logfile(logfile, recent_timestamps, args):
                     last_line_printed = False
             elif args.multi_line and last_line_printed:
                 print(line, end="")
+
 
 def main():
     args = parse_args()

--- a/zabbix-system/monitorKilledProcesses.sh
+++ b/zabbix-system/monitorKilledProcesses.sh
@@ -3,16 +3,7 @@
 # \file      monitorKilledProcesses.sh
 # \brief     Returns the number of lines in /var/log/messages.for killed processes due to lack of virtual memory of the current day
 # \brief     Mar 29 09:29:50 combined kernel: Killed process 15639 (irodsServer) total-vm:913264kB, anon-rss:754528kB, file-rss:4kB, shmem-rss:22556kB
-# \          Initial version
-# \copyright Copyright (c) 2018, Utrecht University. All rights reserved.
-
-#gets current month day
-month=$(date +"%b")
-day=$(date +"%e")
-space=" "
-#month day is constructed according to format in the rodsLog
-monthDay="$month$space$day";
+# \copyright Copyright (c) 2018-2025, Utrecht University. All rights reserved.
 
 # returns count of lines containing Killed process and month day.
-echo $(sudo -u root grep "$monthDay" /var/log/messages | grep "Killed process" | wc -l)
-
+journalctl --since today | grep -c "kernel: Out of memory: Killed process "


### PR DESCRIPTION
This bundles a couple of updates for the rodsLog/messages log checks:
- Verify what distribution (EL or Ubuntu) the killed processes check is running on and ensure that we are reading the right log file for the distribution.
- Adapt rodsLog error rate scripts for the new rods log file paths and timestamp format.
- Adapt rodsLog error rate scripts for error messages that are relevant in iRODS 4.3.x.
- Remove redundant sudo command in killed processes check script