### PR TITLE
YDA-6743: read logs directly for OOM check

### DIFF
--- a/zabbix-system/monitorKilledProcesses.sh
+++ b/zabbix-system/monitorKilledProcesses.sh
@@ -1,9 +1,24 @@
 #!/bin/bash
 
 # \file      monitorKilledProcesses.sh
-# \brief     Returns the number of lines in /var/log/messages.for killed processes due to lack of virtual memory of the current day
-# \brief     Mar 29 09:29:50 combined kernel: Killed process 15639 (irodsServer) total-vm:913264kB, anon-rss:754528kB, file-rss:4kB, shmem-rss:22556kB
-# \copyright Copyright (c) 2018-2025, Utrecht University. All rights reserved.
+# \brief     Returns count of log lines mentioning OOM process kills on the current day
+# \copyright Copyright (c) 2018-2026, Utrecht University. All rights reserved.
 
-# returns count of lines containing Killed process and month day.
-journalctl --since today | grep -c "kernel: Out of memory: Killed process "
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+else
+    echo "Error: could not determine distribution"
+    exit 1
+fi
+
+if [ "$NAME" = "Ubuntu" ]
+then
+    datestamp=$(date +"%Y-%m-%dT")
+    grep "^$datestamp" /var/log/syslog /var/log/syslog.? | grep -c "kernel: Out of memory: Killed process"
+elif [ "$NAME" = "Red Hat Enterprise Linux" ] || [ "$NAME" = "AlmaLinux" ]
+then
+    datestamp=$(date +"%b %e")
+    grep "^$datestamp " /var/log/messages | grep -c "kernel: Out of memory: Killed process"
+else
+    echo "Error: unknown distribution: $NAME"
+fi


### PR DESCRIPTION
Using journalctl can take a long time on production environments, since this also processes all iRODS log messages.