### PR TITLE
YDA-6586: add resource vault check

### DIFF
--- a/template-yoda2.0-generic.yaml
+++ b/template-yoda2.0-generic.yaml
@@ -41,6 +41,16 @@ zabbix_export:
               tags:
                 - tag: Application
                   value: Yoda
+        - uuid: ae9477c7f419441a867883d989e09dd9
+          name: 'iRODS is available'
+          type: ZABBIX_ACTIVE
+          key: yoda.irodsavailable
+          timeout: 10s
+          triggers:
+            - uuid: 24ff70e1f7434bb9a2f486da00663c36
+              expression: 'last(/Yoda 2.0 generic/yoda.irodsavailable,#1)<>0'
+              name: 'iRODS is not available'
+              priority: HIGH
         - uuid: 54be8841c44a462aa745c7ac6f3dc133
           name: yoda.killedprocesses.count
           type: ZABBIX_ACTIVE
@@ -60,3 +70,14 @@ zabbix_export:
               tags:
                 - tag: Application
                   value: Yoda
+        - uuid: 8d2953624b9c469288fb467161013a18
+          name: 'Number of resources with inaccessible vault directories'
+          type: ZABBIX_ACTIVE
+          key: yoda.resourcemountpoints
+          delay: 5m
+          timeout: 30s
+          triggers:
+            - uuid: 5d2d2204ae0f4385a2d30c27d7f19359
+              expression: 'last(/Yoda 2.0 generic/yoda.resourcemountpoints,#1)>0'
+              name: 'Some iRODS vault directories are not accessible'
+              priority: HIGH

--- a/zabbix-irodscommon/test-irods-available.py
+++ b/zabbix-irodscommon/test-irods-available.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+"""This Zabbix check script tests whether iRODS
+   is available.
+
+   It outputs '0' if iRODS is responding within a
+   reasonable amount of time, otherwise '1'"""
+
+import subprocess
+from typing import List, Optional
+
+
+def get_process_returncode_with_timeout(
+        args: List[str], timeout: int) -> Optional[int]:
+    returncode: Optional[int] = None
+    try:
+        process = subprocess.run(args,
+                                 capture_output=True,
+                                 text=True,
+                                 timeout=timeout)
+        returncode = process.returncode
+    except subprocess.TimeoutExpired:
+        pass
+    return returncode
+
+
+def main():
+    returncode = get_process_returncode_with_timeout(["/usr/bin/ils", "/"],
+                                                     10)
+    if returncode is None or returncode > 0:
+        print(1)
+    else:
+        print(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/zabbix-irodscommon/test-resource-mount-points.py
+++ b/zabbix-irodscommon/test-resource-mount-points.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+"""This Zabbix check script verifies whether iRODS unixfilesystem
+   resources vault directories are accessible.
+
+   Printed value:
+   '0'  if resources cannot be listed (e.g. iRODS is not available).
+        Such problems needs to be detected by another separate check.
+
+   Otherwise it prints the number of local vault directories that cannot
+   be detected as available.
+
+   In order for this check to work as expected, vault directories always
+   need to be a subdirectory of the mount point of a volume. If the vault
+   directory is the same as the mount point of the volume, the check script
+   has no reliable way to differentiate an unmounted volume from an empty
+   vault directory, and will therefore not detect any issues.
+"""
+
+import socket
+import subprocess
+import sys
+from typing import Dict, List, Optional, Tuple
+
+
+def get_process_output_with_timeout(
+        args: List[str], timeout: int) -> Tuple[Optional[int], Optional[str]]:
+    returncode: Optional[int] = None
+    output: Optional[str] = None
+    try:
+        process = subprocess.run(args,
+                                 capture_output=True,
+                                 text=True,
+                                 timeout=timeout)
+        returncode = process.returncode
+        output = process.stdout
+    except subprocess.TimeoutExpired:
+        pass
+    return returncode, output
+
+
+def directory_exists_and_fs_accessible(path: str, timeout: int) -> bool:
+    returncode, _ = get_process_output_with_timeout(
+        ["/bin/test", "-d", path], 1)
+    return returncode == 0
+
+
+def get_hostname() -> str:
+    return socket.getfqdn()
+
+
+def get_resource_data() -> Optional[List[Dict[str, str]]]:
+    returncode, output = get_process_output_with_timeout(
+        ["/bin/ilsresc", "-l"], 10)
+    if returncode is None or output is None:
+        return None
+
+    resourcedata: List[Dict[str, str]] = []
+    current_data: Dict[str, str] = dict()
+    for line in output.split("\n"):
+        line = line.rstrip()
+        if ":" in line:
+            keyvalue = line.split(":")[0]
+            value = ":".join(line.split(":")[1:]).lstrip()
+            current_data[keyvalue] = value
+        elif line.startswith("----"):
+            resourcedata.append(current_data)
+            current_data = dict()
+    if len(current_data) > 0:
+        resourcedata.append(current_data)
+
+    return resourcedata
+
+
+def get_num_local_ufs_vault_path_errors(
+        resourcedata: List[Dict[str, str]], hostname: str) -> int:
+    num_errors: int = 0
+    for resource in resourcedata:
+        resource_desc = resource.get("resource name", "unknown resource")
+        resource_loc = resource.get("location", None)
+        resource_type = resource.get("type", None)
+        if (resource_type == "unixfilesystem" and
+                resource_loc == hostname):
+            path = resource.get("vault", None)
+            if path is None:
+                print(
+                    sys.stderr,
+                    f"Warning: UFS resource without vault path: {resource_desc}")
+            elif not directory_exists_and_fs_accessible(path, 2):
+                num_errors += 1
+    return num_errors
+
+
+def main():
+    resourcedata = get_resource_data()
+
+    if resourcedata is None:
+        print(0)
+    else:
+        num_errors = get_num_local_ufs_vault_path_errors(resourcedata,
+                                                         get_hostname())
+        print(num_errors)
+
+
+if __name__ == "__main__":
+    main()

--- a/zabbix-irodscommon/testIrodsAvailable.sh
+++ b/zabbix-irodscommon/testIrodsAvailable.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo -u irods /var/lib/irods/bin/test-irods-available.py

--- a/zabbix-irodscommon/testResourceMountpoints.sh
+++ b/zabbix-irodscommon/testResourceMountpoints.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo -u irods /var/lib/irods/bin/test-resource-mount-points.py

--- a/zabbix-irodscommon/yoda-zabbix-irodscommon-sudoers
+++ b/zabbix-irodscommon/yoda-zabbix-irodscommon-sudoers
@@ -1,2 +1,4 @@
-zabbix ALL=NOPASSWD: /etc/zabbix/zabbix_agentd.d/dailyRodslogErrors.sh
-zabbix ALL=NOPASSWD: /etc/zabbix/zabbix_agentd.d/hourlyRodslogErrors.sh
+zabbix ALL=NOPASSWD: /etc/zabbix/zabbix_agent2.d/dailyRodslogErrors.sh
+zabbix ALL=NOPASSWD: /etc/zabbix/zabbix_agent2.d/hourlyRodslogErrors.sh
+zabbix ALL=NOPASSWD: /etc/zabbix/zabbix_agent2.d/testIrodsAvailable.sh
+zabbix ALL=NOPASSWD: /etc/zabbix/zabbix_agent2.d/testResourceMountpoints.sh

--- a/zabbix-irodscommon/yoda_irodscommon.userparams.conf
+++ b/zabbix-irodscommon/yoda_irodscommon.userparams.conf
@@ -20,5 +20,7 @@
 #
 # Mandatory: no
 # Default:
-UserParameter=yoda.dailyrodslogerrors,sudo /etc/zabbix/zabbix_agentd.d/dailyRodslogErrors.sh
-UserParameter=yoda.hourlyrodslogerrors,sudo /etc/zabbix/zabbix_agentd.d/hourlyRodslogErrors.sh
+UserParameter=yoda.dailyrodslogerrors,sudo /etc/zabbix/zabbix_agent2.d/dailyRodslogErrors.sh
+UserParameter=yoda.hourlyrodslogerrors,sudo /etc/zabbix/zabbix_agent2.d/hourlyRodslogErrors.sh
+UserParameter=yoda.resourcemountpoints,sudo /etc/zabbix/zabbix_agent2.d/testResourceMountpoints.sh
+UserParameter=yoda.irodsavailable,sudo /etc/zabbix/zabbix_agent2.d/testIrodsAvailable.sh


### PR DESCRIPTION
Add check for presence of vault directories of unixfilesystem resources. This helps detect situations in which iRODS vault volumes have not been mounted correctly.

Also add separate check for availability of iRODS itself, since this check won't work if iRODS is unavailable.